### PR TITLE
ca-certificate issue in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ MAINTAINER Greg Poirier <greg@opsee.co>
 
 RUN apk update && \
     apk add bash && \
+    apk add ca-certificates && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /opt/bin
 
 COPY target/linux/amd64/* /opt/bin/
+ENV PATH /opt/bin:$PATH
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Added ca-certificates to fix the following error:

```
Dans-MacBook-Pro-2:vinz-clortho dancompton$ docker run -e AWS_ACCESS_KEY_ID='redacted' -e AWS_SECRET_ACCESS_KEY='redacted' -e AWS_DEFAULT_REGION='redacted' vinz-clortho vinz-clortho s3kms get -b keys -o blah
0x43f4a0
0x43f4a0
0x43f4a0
RequestError: send request failed
caused by: Get https://opsee-keys.s3-us-west-2.amazonaws.com/dev/blah: x509: failed to load system roots and no roots provided
```

Added /opts/bin to path via ENV in dockerfile.  I'm not at all sure why it's not in the path for gliderlabs/alpine (?).  I might be doing something wrong.
